### PR TITLE
Add PostgreSQL driver and package init files

### DIFF
--- a/face_attendance_app/__init__.py
+++ b/face_attendance_app/__init__.py
@@ -1,0 +1,2 @@
+"""Top-level package for the face attendance application."""
+

--- a/face_attendance_app/app/__init__.py
+++ b/face_attendance_app/app/__init__.py
@@ -1,0 +1,2 @@
+"""Application package containing API and database code."""
+

--- a/face_attendance_app/requirements-lock.txt
+++ b/face_attendance_app/requirements-lock.txt
@@ -11,6 +11,7 @@ python-multipart==0.0.6
 jinja2==3.1.2
 aiofiles==23.2.1
 sqlalchemy==2.0.23
+psycopg2-binary==2.9.9
 onnxruntime==1.16.0
 
 # Additional dependencies that might be required

--- a/face_attendance_app/requirements.txt
+++ b/face_attendance_app/requirements.txt
@@ -8,4 +8,5 @@ python-multipart==0.0.6
 jinja2==3.1.2
 aiofiles==23.2.1
 sqlalchemy==2.0.23
+psycopg2-binary==2.9.9
 onnxruntime==1.16.0


### PR DESCRIPTION
## Summary
- add psycopg2-binary dependency so Postgres works when containerized
- mark face_attendance_app modules as packages with __init__ files

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `docker compose config` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68969e1edab48330b8fbcaf55d3dd7f2